### PR TITLE
Handle empty or non-existent expected directories

### DIFF
--- a/pkg/theme/theme.go
+++ b/pkg/theme/theme.go
@@ -162,6 +162,10 @@ func listDirectory(dir string) ([]string, error) {
 	var files []string
 
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if info == nil {
+			klog.Warningf("%s dir is empty", dir)
+			return nil
+		}
 		if !info.IsDir() {
 			files = append(files, path)
 		}


### PR DESCRIPTION
Was throwing a nil pointer deference error and stopping the entire tool from running. Now outputs a warning and continues.