### PR TITLE
Update org name references

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This will output the `MyTheme.xml` file that can be uploaded as a full Jcink "sk
 
 ### OSX
 
-You can find the latest release [on the releases page](https://github.com/rp-magrathea/cybertron/releases/latest)
+You can find the latest release [on the releases page](https://github.com/magratheaguide/cybertron/releases/latest)
 
 1. Download the latest binary for Darwin
 1. Rename to `cybertron`
@@ -75,4 +75,4 @@ If you get a security error trying to run Cybertron:
 
 ### Windows
 
-Download the latest .exe file from the [releases page](https://github.com/rp-magrathea/cybertron/releases/latest). Run it from there and use the `-d` and `-o` flags.
+Download the latest .exe file from the [releases page](https://github.com/magratheaguide/cybertron/releases/latest). Run it from there and use the `-d` and `-o` flags.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/klog"
 
-	"github.com/rp-magrathea/cybertron/pkg/theme"
+	"github.com/magratheaguide/cybertron/pkg/theme"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rp-magrathea/cybertron
+module github.com/magratheaguide/cybertron
 
 go 1.16
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/rp-magrathea/cybertron/cmd"
+	"github.com/magratheaguide/cybertron/cmd"
 )
 
 var (


### PR DESCRIPTION
The GitHub org name has changed from `rp-magrathea` to `magratheaguide`. All URLs and references need to be updated accordingly.